### PR TITLE
fix(search-index): add missing param [analyzer_parameter] when creating search index with field schema [text]

### DIFF
--- a/lib/ex_aliyun_ots/client/search.ex
+++ b/lib/ex_aliyun_ots/client/search.ex
@@ -413,16 +413,16 @@ defmodule ExAliyunOts.Client.Search do
     end
   end
 
-  def prepare_analyzer_parameter("single_word", parameter) when is_map(parameter), do:
+  def prepare_analyzer_parameter("single_word", parameter) when is_map(parameter) or is_list(parameter), do:
     do_prepare_analyzer_parameter(SingleWordAnalyzerParameter, parameter)
 
-  def prepare_analyzer_parameter("split", parameter) when is_map(parameter), do:
+  def prepare_analyzer_parameter("split", parameter) when is_map(parameter) or is_list(parameter), do:
     do_prepare_analyzer_parameter(SplitAnalyzerParameter, parameter)
 
-  def prepare_analyzer_parameter("fuzzy", parameter) when is_map(parameter), do:
+  def prepare_analyzer_parameter("fuzzy", parameter) when is_map(parameter) or is_list(parameter), do:
     do_prepare_analyzer_parameter(FuzzyAnalyzerParameter, parameter)
 
-  def prepare_analyzer_parameter(analyzer, parameter) when is_atom(analyzer) and is_map(parameter), do:
+  def prepare_analyzer_parameter(analyzer, parameter) when is_atom(analyzer), do:
     prepare_analyzer_parameter(to_string(analyzer), parameter)
 
   def prepare_analyzer_parameter(_analyzer, _parameter), do: nil

--- a/lib/ex_aliyun_ots/metadata.ex
+++ b/lib/ex_aliyun_ots/metadata.ex
@@ -213,6 +213,7 @@ defmodule ExAliyunOts.Var.Search do
               field_type: FieldType.keyword(),
               index_options: nil,
               analyzer: nil,
+              analyzer_parameter: nil,
               index: true,
               enable_sort_and_agg: true,
               store: true,

--- a/lib/ex_aliyun_ots/search.ex
+++ b/lib/ex_aliyun_ots/search.ex
@@ -1349,6 +1349,8 @@ defmodule ExAliyunOts.Search do
     * `:is_array`, specifies whether the stored data is a JSON encoded list as a string, e.g. `"[\"a\",\"b\"]"`.
     * `:analyzer`, optional, please see analyzer document in [Chinese](https://help.aliyun.com/document_detail/120227.html) |
     [English](https://www.alibabacloud.com/help/doc-detail/120227.html).
+    * `:analyzer_parameter`, optional, please see analyzer document in [Chinese](https://help.aliyun.com/document_detail/120227.html) |
+    [English](https://www.alibabacloud.com/help/doc-detail/120227.html).
   """
   @doc field_schema: :field_schema
   def field_schema_text(field_name, options \\ []) do
@@ -1418,6 +1420,7 @@ defmodule ExAliyunOts.Search do
     schema
     |> do_map_field_schema(options)
     |> Map.put(:analyzer, Keyword.get(options, :analyzer, nil))
+    |> Map.put(:analyzer_parameter, Keyword.get(options, :analyzer_parameter, nil))
   end
 
   defp map_field_schema(schema, options) when is_map(schema) do

--- a/test/mixin/search_test.exs
+++ b/test/mixin/search_test.exs
@@ -11,6 +11,8 @@ defmodule ExAliyunOts.MixinTest.Search do
   @indexes ["test_search_index", "test_search_index2"]
   @table_group_by "test_search_group_by"
   @index_group_by "test_search_index_group_by"
+  @table_text_analyzer "test_search_text_analyzer"
+  @index_text_analyzer "test_search_index_text_analyzer"
 
   setup_all do
     Application.ensure_all_started(:ex_aliyun_ots)
@@ -18,7 +20,9 @@ defmodule ExAliyunOts.MixinTest.Search do
 
     TestSupportSearch.init(@instance_key, @table, @indexes,
       table_group_by: @table_group_by,
-      index_group_by: @index_group_by
+      index_group_by: @index_group_by,
+      table_text_analyzer: @table_text_analyzer,
+      index_text_analyzer: @index_text_analyzer
     )
 
     on_exit(&clean_all/0)
@@ -29,6 +33,12 @@ defmodule ExAliyunOts.MixinTest.Search do
   defp clean_all do
     TestSupportSearch.clean(@instance_key, @table, @indexes)
     TestSupportSearch.clean_group_by(@instance_key, @table_group_by, @index_group_by)
+
+    TestSupportSearch.clean_text_analyzer(
+      @instance_key,
+      @table_text_analyzer,
+      @index_text_analyzer
+    )
   end
 
   test "list search index" do
@@ -1348,5 +1358,186 @@ defmodule ExAliyunOts.MixinTest.Search do
     assert result == :ok
 
     delete_search_index(@table, index_name)
+  end
+
+  test "describe search index with text analyzer" do
+    {:ok, response} = describe_search_index(@table_text_analyzer, @index_text_analyzer)
+    schema = response.schema
+
+    schema.field_schemas
+    |> Enum.with_index()
+    |> Enum.map(fn {field_schema, index} ->
+      cond do
+        index == 0 ->
+          assert field_schema.field_name == "text_single_word_1"
+          assert field_schema.field_type == FieldType.text()
+
+        index == 1 ->
+          assert field_schema.field_name == "text_single_word_2"
+          assert field_schema.field_type == FieldType.text()
+          assert field_schema.analyzer == "single_word"
+          assert field_schema.analyzer_parameter.case_sensitive == true
+          assert field_schema.analyzer_parameter.delimit_word == true
+
+        index == 2 ->
+          assert field_schema.field_name == "text_split_1"
+          assert field_schema.field_type == FieldType.text()
+          assert field_schema.analyzer == "split"
+
+        index == 3 ->
+          assert field_schema.field_name == "text_split_2"
+          assert field_schema.field_type == FieldType.text()
+          assert field_schema.analyzer == "split"
+          assert field_schema.analyzer_parameter.delimiter == ":"
+
+        index == 4 ->
+          assert field_schema.field_name == "text_fuzzy"
+          assert field_schema.field_type == FieldType.text()
+          assert field_schema.analyzer == "fuzzy"
+          assert field_schema.analyzer_parameter.min_chars == 2
+          assert field_schema.analyzer_parameter.max_chars == 7
+      end
+    end)
+  end
+
+  test "search - match query single word default (not case_sensitive)" do
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_1",
+            text: "tincDdunt" |> String.downcase()
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+  end
+
+  test "search - match query single word default (not delimit_word)" do
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_1",
+            text: "loBortis111" |> String.downcase()
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+  end
+
+  test "search - match query single word case_sensitive" do
+    # downcase
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_2",
+            text: "Pulvinar" |> String.downcase()
+          ]
+        ]
+      )
+
+    assert response.total_hits == 0
+    assert length(response.rows) == 0
+
+    # origin
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_2",
+            text: "Pulvinar"
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+  end
+
+  test "search - match query single word delimit_word" do
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_2",
+            text: "Gravida"
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_single_word_2",
+            text: "999"
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+  end
+
+  test "search - match query fuzzy" do
+    # cannot get result when text length < 2 since min_chars = 2
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_fuzzy",
+            text: "m"
+          ]
+        ]
+      )
+
+    assert response.total_hits == 0
+    assert length(response.rows) == 0
+
+    # can get result when text length = 2
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_fuzzy",
+            text: "mc"
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
+
+    # case insensitive
+    {:ok, response} =
+      search(@table_text_analyzer, @index_text_analyzer,
+        search_query: [
+          query: [
+            type: QueryType.match(),
+            field_name: "text_fuzzy",
+            text: "mattIs" |> String.downcase()
+          ]
+        ]
+      )
+
+    assert response.total_hits == 1
+    assert length(response.rows) == 1
   end
 end

--- a/test/support/search.ex
+++ b/test/support/search.ex
@@ -282,7 +282,9 @@ defmodule ExAliyunOtsTest.Support.Search do
         text_single_word_2: "Pulvinar Proin Gravida999 Hendrerit lectus",
         text_split_1: "consequat id po88:rta nibh venenatis",
         text_split_2: "velit:digniss11im:sodales:ut:eu",
-        text_fuzzy: "mattIs ullamcor22per velit sed ullamcorper"
+        text_fuzzy: "mattIs ullamcor22per velit sed ullamcorper",
+        text_min_word: "梨花茶",
+        text_max_word: "梨花茶"
       }
     ]
 
@@ -418,10 +420,21 @@ defmodule ExAliyunOtsTest.Support.Search do
             analyzer: "fuzzy",
             # type could be keyword either
             analyzer_parameter: [min_chars: 2, max_chars: 7]
+          },
+          %Search.FieldSchema{
+            field_name: "text_min_word",
+            field_type: FieldType.text(),
+            analyzer: "min_word"
+          },
+          %Search.FieldSchema{
+            field_name: "text_max_word",
+            field_type: FieldType.text(),
+            analyzer: "max_word"
           }
         ]
       }
     }
+
     result = Client.create_search_index(instance_key, var_request)
     Logger.info("create_search_index for text analyzer test: #{inspect(result)}")
   end

--- a/test/support/search.ex
+++ b/test/support/search.ex
@@ -409,13 +409,15 @@ defmodule ExAliyunOtsTest.Support.Search do
             field_name: "text_split_2",
             field_type: FieldType.text(),
             analyzer: "split",
+            # type could be map
             analyzer_parameter: %{delimiter: ":"}
           },
           %Search.FieldSchema{
             field_name: "text_fuzzy",
             field_type: FieldType.text(),
             analyzer: "fuzzy",
-            analyzer_parameter: %{min_chars: 2, max_chars: 7}
+            # type could be keyword either
+            analyzer_parameter: [min_chars: 2, max_chars: 7]
           }
         ]
       }


### PR DESCRIPTION
## AnalyzerParameter 是什么

1. 具体阿里云文档参考: https://help.aliyun.com/document_detail/120227.htm
2. 参数格式参考: https://github.com/xinz/tablestore_protos/blob/master/protos/search.proto#L258 
3. 概括来说, 当创建多元索引时, 某字段为 text 类型, 这时可以选择分词的类型, 而 `analyzer_parameter`则是不同分词下可以设置的一些配置, 如是否大小写敏感等


## 目前存在的问题

1. 在创建多元索引时, 当前版本没有将 `analyzer_parameter` 参数传递至 Tablestore, 因此会导致只能够使用默认设置
2. 另外特别的, 当分词类型是 `fuzzy` 时, 如果不设置 `analyzer_parameter`, 按照官方文档所说 `min_chars` 与 `max_chars` 的默认设置应分别为 `1` 和 `3`. 但实际情况与文档描述不同, 如果不设置  `analyzer_parameter`, `min_chars` 与 `max_chars` 会没有默认值, 导致该索引无法按照预期去工作, 使用该索引字段去搜索时, 永远只能得到 0 条数据

## 解决方法

1. 宏 `field_schema_text` 添加 `analyzer_parameter` 可选参数, 将参数继续往下面带
2. `Client` 中 `remote_create_search_index` 时, 在构建请求前添加对 `analyzer_parameter` 的相关处理, 将 `map` 转化为 `protobuf bytes`
3. `Client` 中 `remote_describe_search_index` 时, 添加对请求返回值的 decode, 将原始的 `protobuf bytes` 转化为 `map`
4. 补充相关单元测试