### PR TITLE
(Fix) fix elixir 1.13 compile error

### DIFF
--- a/lib/ex_aliyun_ots/merge_compiler.ex
+++ b/lib/ex_aliyun_ots/merge_compiler.ex
@@ -2,9 +2,14 @@ defmodule ExAliyunOts.MergeCompiler do
   @moduledoc false
 
   @merge_modules [ExAliyunOts.DSL]
+  @compile {:no_warn_undefined, {Mix.Project, :project_file, 0}}
 
   defp base_path do
-    Enum.find(Mix.Project.config_files, &(&1 =~ ~r/mix.exs/)) |> Path.dirname
+    if function_exported?(Mix.Project, :project_file, 0) do
+      Mix.Project.project_file() |> Path.dirname()
+    else
+      Enum.find(Mix.Project.config_files(), &(&1 =~ ~r/mix.exs/)) |> Path.dirname()
+    end
   end
 
   defmacro __before_compile__(_env) do
@@ -25,6 +30,5 @@ defmodule ExAliyunOts.MergeCompiler do
       {:defmodule, _c_m, [_alias, [do: {:__block__, _, defs}]]} = ast
       [quote(do: @external_resource(unquote(file))), defs]
     end)
-
   end
 end


### PR DESCRIPTION
fix compile error with elixir 1.13.0-rc.0 version 
```elixir
== Compilation error in file lib/ex_aliyun_ots.ex ==
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1    
    
    The following arguments were given to IO.chardata_to_string/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 2 out of 2):
    
        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)
    
    (elixir 1.13.0-rc.0) lib/io.ex:627: IO.chardata_to_string/1
    (elixir 1.13.0-rc.0) lib/path.ex:423: Path.dirname/1
    expanding macro: ExAliyunOts.MergeCompiler.__before_compile__/1
    lib/ex_aliyun_ots.ex:1: ExAliyunOts (module)
```

mix.exs file has been moved to its own function called project_file/0