### PR TITLE
Fix filter compile error when wrong quote

### DIFF
--- a/lib/ex_aliyun_ots/filter.ex
+++ b/lib/ex_aliyun_ots/filter.ex
@@ -94,7 +94,7 @@ defmodule ExAliyunOts.Filter do
 
     quote do
       %Filter{
-        type: FilterType.composite_column(),
+        type: unquote(FilterType.composite_column()),
         filter: %CompositeColumnValueFilter{
           combinator: unquote(combinator),
           sub_filters: unquote(sub_filters)
@@ -105,12 +105,13 @@ defmodule ExAliyunOts.Filter do
 
   defp single_filter({comparator, _, [column_name, column_value]}) do
     comparator = @comparator_mapping[comparator]
+    filter_type = FilterType.single_column()
 
-    quote location: :keep, bind_quoted: [column_name: column_name, column_value: column_value, comparator: comparator] do
+    quote location: :keep, bind_quoted: [column_name: column_name, column_value: column_value, comparator: comparator, filter_type: filter_type] do
       case column_name do
         {column_name, column_options} ->
           %Filter{
-            type: FilterType.single_column(),
+            type: filter_type,
             filter: %SingleColumnValueFilter{
               comparator: comparator,
               column_name: column_name,
@@ -123,7 +124,7 @@ defmodule ExAliyunOts.Filter do
 
         column_name ->
           %Filter{
-            type: FilterType.single_column(),
+            type: filter_type,
             filter: %SingleColumnValueFilter{
               comparator: comparator,
               column_name: column_name,

--- a/test/mixin/filter_test.exs
+++ b/test/mixin/filter_test.exs
@@ -123,4 +123,15 @@ defmodule ExAliyunOts.MixinTest.Filter do
       )
     end
   end
+
+  test "build filter to ensure successfully quoted" do
+    {%ExAliyunOts.TableStoreFilter.Filter{filter: filter, type: type}, _} = ExAliyunOts.Filter.build_filter({:==, "some", [:a, 1]}) |> Code.eval_quoted()
+    assert filter.column_name == :a and filter.column_value == 1 and type == :FT_SINGLE_COLUMN_VALUE
+
+    {%ExAliyunOts.TableStoreFilter.Filter{filter: filter, type: type}, _} = ExAliyunOts.Filter.build_filter({:and, "some", [{:==, "some", [:b, 2]}, {:>=, "some", [:c, 10]}]}) |> Code.eval_quoted()
+    assert type == :FT_COMPOSITE_COLUMN_VALUE
+    [%{filter: sub1}, %{filter: sub2}] = filter.sub_filters
+    assert sub1.comparator == :CT_EQUAL and sub1.column_name == :b and sub1.column_value == 2
+    assert sub2.comparator == :CT_GREATER_EQUAL and sub2.column_name == :c and sub2.column_value == 10
+  end
 end


### PR DESCRIPTION
Error involved in #38 

```
** (CompileError) nofile:1: you must require ExAliyunOts.Const.FilterType before invoking the
macro ExAliyunOts.Const.FilterType.composite_column/0
```

or 

```
 ** (CompileError) nofile:1: you must require ExAliyunOts.Const.FilterType before invoking the
macro ExAliyunOts.Const.FilterType.single_column/0
```

Now the corresponding test case added to cover it.
