### PR TITLE
Fix source link in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,6 +61,7 @@ defmodule ExAliyunOts.Mixfile do
     [
       main: "readme",
       source_url: @source_url,
+      source_ref: "master",
       formatter_opts: [gfm: true],
       extras: [
         "README.md",


### PR DESCRIPTION
The view source link is broken due to the `exdoc` changing the default `:source_ref` to the `main` branch.