### PR TITLE
feat: support &&/|| for filter

### DIFF
--- a/lib/ex_aliyun_ots/const.ex
+++ b/lib/ex_aliyun_ots/const.ex
@@ -163,7 +163,7 @@ defmodule ExAliyunOts.Const.LogicOperator do
   const(:not, :LO_NOT)
   const(:and, :LO_AND)
   const(:or, :LO_OR)
-  def mapping, do: %{not: :LO_NOT, and: :LO_AND, or: :LO_OR}
+  def mapping, do: %{not: :LO_NOT, and: :LO_AND, &&: :LO_AND, ||: :LO_OR, or: :LO_OR}
 end
 
 defmodule ExAliyunOts.Const.ComparatorType do

--- a/lib/ex_aliyun_ots/filter.ex
+++ b/lib/ex_aliyun_ots/filter.ex
@@ -72,7 +72,7 @@ defmodule ExAliyunOts.Filter do
   end
 
   @doc false
-  def build_filter({combinator, _, _} = ast) when combinator in [:and, :not, :or] do
+  def build_filter({combinator, _, _} = ast) when combinator in [:and, :&&, :not, :or, :||] do
     composite_filter(ast)
   end
 

--- a/test/mixin/filter_test.exs
+++ b/test/mixin/filter_test.exs
@@ -78,6 +78,8 @@ defmodule ExAliyunOts.MixinTest.Filter do
 
     filter_result_2 = filter(name_with_age_expr or class_field == "1")
 
+    assert filter("class" == "1" and "age" >= 1) == filter("class" == "1" && "age" >= 1)
+    assert filter("class" == "1" or "age" >= 1) == filter("class" == "1" || "age" >= 1)
     assert filter_result == @result
     assert filter_result_1 == @result
     assert filter_result_2 == @result


### PR DESCRIPTION
support `&&` / `||` for filter

```elixir
# and == &&
filter("class" == "1" and "age" >= 1) == filter("class" == "1" && "age" >= 1)

# or == ||
filter("class" == "1" or "age" >= 1) == filter("class" == "1" || "age" >= 1)
```