### PR TITLE
Fix compile warning negative steps are not supported in String.slice/2

### DIFF
--- a/lib/ex_aliyun_ots.ex
+++ b/lib/ex_aliyun_ots.ex
@@ -1421,7 +1421,7 @@ defmodule ExAliyunOts do
 
   ReturnType.constants()
   |> Enum.map(fn {_value, type} ->
-    downcase_type = type |> to_string() |> String.slice(3..-1) |> Utils.downcase_atom()
+    downcase_type = type |> to_string() |> String.slice(3..-1//1) |> Utils.downcase_atom()
 
     defp map_return_type(unquote(downcase_type)), do: unquote(type)
     defp map_return_type(unquote(type)), do: unquote(type)

--- a/lib/ex_aliyun_ots/client/table.ex
+++ b/lib/ex_aliyun_ots/client/table.ex
@@ -325,7 +325,7 @@ defmodule ExAliyunOts.Client.Table do
   DefinedColumnType.constants()
   |> Enum.map(fn {_value, type} ->
     downcase_type =
-      type |> to_string() |> String.slice(4..-1) |> Utils.downcase_atom()
+      type |> to_string() |> String.slice(4..-1//1) |> Utils.downcase_atom()
 
     defp map_defined_column_schema({key_name, unquote(downcase_type)}),
       do: %DefinedColumnSchema{name: key_name, type: unquote(type)}


### PR DESCRIPTION
Fix the following compile warning with Elixir 1.16.3

```
==> ex_aliyun_ots
Compiling 15 files (.ex)
warning: negative steps are not supported in String.slice/2, pass 4..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots/client/table.ex:328: anonymous fn/1 in :elixir_compiler_3.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots/client/table.ex:326: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4
  (elixir 1.16.3) src/elixir_compiler.erl:52: :elixir_compiler.compile/4

warning: negative steps are not supported in String.slice/2, pass 4..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots/client/table.ex:328: anonymous fn/1 in :elixir_compiler_3.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots/client/table.ex:326: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4

warning: negative steps are not supported in String.slice/2, pass 4..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots/client/table.ex:328: anonymous fn/1 in :elixir_compiler_3.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots/client/table.ex:326: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4

warning: negative steps are not supported in String.slice/2, pass 4..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots/client/table.ex:328: anonymous fn/1 in :elixir_compiler_3.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots/client/table.ex:326: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4

warning: negative steps are not supported in String.slice/2, pass 4..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots/client/table.ex:328: anonymous fn/1 in :elixir_compiler_3.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots/client/table.ex:326: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4

warning: negative steps are not supported in String.slice/2, pass 3..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots.ex:1424: anonymous fn/1 in :elixir_compiler_24.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots.ex:1423: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4
  (elixir 1.16.3) src/elixir_compiler.erl:52: :elixir_compiler.compile/4

warning: negative steps are not supported in String.slice/2, pass 3..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots.ex:1424: anonymous fn/1 in :elixir_compiler_24.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots.ex:1423: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4

warning: negative steps are not supported in String.slice/2, pass 3..-1//1 instead
  (elixir 1.16.3) lib/string.ex:2369: String.slice/2
  lib/ex_aliyun_ots.ex:1424: anonymous fn/1 in :elixir_compiler_24.__MODULE__/1
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
  lib/ex_aliyun_ots.ex:1423: (module)
  (elixir 1.16.3) src/elixir_compiler.erl:67: :elixir_compiler.dispatch/4
```